### PR TITLE
Suggested Changes

### DIFF
--- a/example-hp4100.plist
+++ b/example-hp4100.plist
@@ -16,6 +16,8 @@
 	<string>Front Desk</string>
 	<key>address</key>
 	<string>hp-4100</string>
+	<key>default_catalog</key>
+	<string>development</string>
 	<key>requires</key>
 	<array>
 		<string>HPPrinterDrivers</string>

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -223,7 +223,7 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
     name_opt = '--name=%s' % name
     version_opt = '--pkgvers=%s' % version
     # make pkg info
-    cmd = [makepkginfo, installcheck_option, postinstall_option, uninstall_option, name_opt, version_opt, '--unattended_install', '--uninstall_method=script', '--nopkg']
+    cmd = [makepkginfo, installcheck_option, postinstall_option, uninstall_option, name_opt, version_opt, '--unattended_install', '--uninstall_method=uninstall_script', '--nopkg']
 
     task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = task.communicate()
@@ -235,7 +235,9 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
         requires = plist_opts.get('requires')
         pkginfo['requires'] = requires
 
+
     print plistlib.writePlistToString(pkginfo)
+
 
     # print and clean up
 if __name__ == '__main__':

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -49,6 +49,11 @@ def main():
         options = None
 
     try:
+        catalog = plist_opts['default_catalog']
+    except:
+        catalog = 'testing'
+
+    try:
         protocol = plist_opts['protocol']
     except:
         protocol = 'lpd'
@@ -219,12 +224,12 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
     f.close()
     uninstall_option = "--uninstall_script=%s" % uninstall
 
-
+    catalog_opt =str('-c '+catalog)
     name_opt = '--name=%s' % name
     version_opt = '--pkgvers=%s' % version
     # make pkg info
-    cmd = [makepkginfo, installcheck_option, postinstall_option, uninstall_option, name_opt, version_opt, '--unattended_install', '--uninstall_method=uninstall_script', '--nopkg']
-
+    cmd = [makepkginfo, installcheck_option, postinstall_option, uninstall_option, name_opt, version_opt, catalog_opt, '--unattended_install', '--uninstall_method=uninstall_script', '--nopkg']
+    
     task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = task.communicate()
 

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -236,9 +236,8 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
         pkginfo['requires'] = requires
 
     # Add Uninstallable flag
-    if plist_opts['uninstallable']:
-        uninstallable = plist_opts.get('uninstallable')
-        pkginfo['uninstallable'] = uninstallable
+    uninstallable = True
+    pkginfo['uninstallable'] = uninstallable
 
 
     print plistlib.writePlistToString(pkginfo)

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -229,7 +229,7 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
     version_opt = '--pkgvers=%s' % version
     # make pkg info
     cmd = [makepkginfo, installcheck_option, postinstall_option, uninstall_option, name_opt, version_opt, catalog_opt, '--unattended_install', '--uninstall_method=uninstall_script', '--nopkg']
-    
+
     task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = task.communicate()
 
@@ -244,9 +244,7 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
     uninstallable = True
     pkginfo['uninstallable'] = uninstallable
 
-
     print plistlib.writePlistToString(pkginfo)
-
 
     # print and clean up
 if __name__ == '__main__':

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -235,6 +235,11 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
         requires = plist_opts.get('requires')
         pkginfo['requires'] = requires
 
+    # Add Uninstallable flag
+    if plist_opts['uninstallable']:
+        uninstallable = plist_opts.get('uninstallable')
+        pkginfo['uninstallable'] = uninstallable
+
 
     print plistlib.writePlistToString(pkginfo)
 


### PR DESCRIPTION
changed --uninstall_method=script to --uninstall_method=uninstall_script to bring it inline with https://github.com/munki/munki/wiki/Supported-Pkginfo-Keys.

added default_catalog as an option so that the default catalog can be specified when creating recipe plist.

set it so that the uninstallable option is added in and set to True,
without actually specifying it to be uninstallable munki will not attempt to run the uninstall script.