### PR TITLE
removed trailing space from -c to stop additional space

### DIFF
--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -224,7 +224,7 @@ rm -f /private/etc/cups/deployment/receipts/$printerName.plist
     f.close()
     uninstall_option = "--uninstall_script=%s" % uninstall
 
-    catalog_opt =str('-c '+catalog)
+    catalog_opt =str('-c'+catalog)
     name_opt = '--name=%s' % name
     version_opt = '--pkgvers=%s' % version
     # make pkg info


### PR DESCRIPTION
Fixing an issue with my previous merge,
due to having "-c "+catalog it resulted in an additional space being added into the makepkginfo tool,
resulting in " testing" to occur instead of "testing"

This merge resolves this issue.