### PR TITLE
Fix version comparison function to be the same as used by munki

### DIFF
--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -139,7 +139,16 @@ else
     storedVersion="0"
 fi
 
-versionComparison=$(echo "$storedVersion < $currentVersion" | bc -l)
+usr/bin/python - $storedVersion $currentVersion <<'EOF'
+import sys
+sys.path.append("/usr/local/munki")
+from munkilib import munkicommon as munkicommon
+if munkicommon.MunkiLooseVersion(sys.argv[1]) < munkicommon.MunkiLooseVersion(sys.argv[2]):
+    sys.exit(1)
+sys.exit(0)
+EOF
+versionComparison=$?
+
 # This will be 0 if the current receipt is greater than or equal to current version of the script
 
 ### Printer Install ###
@@ -184,7 +193,15 @@ else
     storedVersion="0"
 fi
 
-versionComparison=$(echo "$storedVersion < $currentVersion" | bc -l)
+usr/bin/python - $storedVersion $currentVersion <<'EOF'
+import sys
+sys.path.append("/usr/local/munki")
+from munkilib import munkicommon as munkicommon
+if munkicommon.MunkiLooseVersion(sys.argv[1]) < munkicommon.MunkiLooseVersion(sys.argv[2]):
+    sys.exit(1)
+sys.exit(0)
+EOF
+versionComparison=$?
 # This will be 0 if the current receipt is greater than or equal to current version of the script
 
 ### Printer Install ###

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -153,7 +153,7 @@ versionComparison=$?
 
 ### Printer Install ###
 # If the queue already exists (returns 0), we don't need to reinstall it.
-/usr/bin/lpstat -p "$printername"
+/usr/bin/lpstat -p "$printername" > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     if [ "$versionComparison" -eq 0 ]; then
         # We are at the current or greater version
@@ -206,7 +206,7 @@ versionComparison=$?
 
 ### Printer Install ###
 # If the queue already exists (returns 0), we don't need to reinstall it.
-/usr/bin/lpstat -p "$printername"
+/usr/bin/lpstat -p "$printername" > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     if [ "$versionComparison" -eq 0 ]; then
         # We are at the current or greater version

--- a/printer-pkginfo
+++ b/printer-pkginfo
@@ -139,7 +139,7 @@ else
     storedVersion="0"
 fi
 
-usr/bin/python - $storedVersion $currentVersion <<'EOF'
+/usr/bin/python - $storedVersion $currentVersion <<'EOF'
 import sys
 sys.path.append("/usr/local/munki")
 from munkilib import munkicommon as munkicommon
@@ -193,7 +193,7 @@ else
     storedVersion="0"
 fi
 
-usr/bin/python - $storedVersion $currentVersion <<'EOF'
+/usr/bin/python - $storedVersion $currentVersion <<'EOF'
 import sys
 sys.path.append("/usr/local/munki")
 from munkilib import munkicommon as munkicommon


### PR DESCRIPTION
...rather than using bc (which could only handle strictly numeric versions).

It seems to me that using bc to compare versions is less than ideal - I fell over it straight away. Version comparison is probably best performed using munki's own version comparison, so that's what this patch does.